### PR TITLE
fix(app): add missing `UNotifications` component

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -26,5 +26,6 @@ useSeoMeta({
   </UMain>
 
   <Footer />
+
   <UNotifications />
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

No issue has been created.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the notifications / toast aren't working in the landing template, because `<UNotifications />` is missing.


### 🐞 Reproduction

Go to the [Landing page demo](https://landing-template.nuxt.dev/).
At the bottom, the "subscribe our newsletter" part should display at toast after a short `setTimeout` (cf. [Footer.vue](https://github.com/nuxt-ui-pro/landing/blob/2023970f88cdd29f085c398e4f2ef92f27a9fdaa/components/Footer.vue#L46-L48)), but that can't work because `UNotifications` is missing in the app.