### PR TITLE
fix: sharp ignored by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       "better-sqlite3"
     ],
     "ignoredBuiltDependencies": [
-      "vue-demi"
+      "vue-demi",
+      "sharp"
     ]
   },
   "packageManager": "pnpm@10.13.1"


### PR DESCRIPTION
Here’s a clear, copy-paste-ready GitHub issue you can post:

### Title

Nuxt UI Pro + @nuxt/image on pnpm v10 → IPX 500 due to `sharp` install scripts blocked/ignored by default

### Describe the bug

On a fresh Nuxt UI Pro landing template using **pnpm v10**, image rendering via `@nuxt/image` (IPX provider) fails at runtime with a 500:

```
[500] [IPX_ERROR] 
Something went wrong installing the "sharp" module

Cannot find module '../build/Release/sharp-darwin-arm64v8.node'
Require stack:
- node_modules/.pnpm/sharp@0.32.6/node_modules/sharp/lib/sharp.js
- node_modules/.pnpm/sharp@0.32.6/node_modules/sharp/lib/constructor.js
- node_modules/.pnpm/sharp@0.32.6/node_modules/sharp/lib/index.js
```

IPX is the default optimizer for `@nuxt/image` and is **based on `sharp`**, so if `sharp` isn’t built/available, the provider fails with 500s. ([[Nuxt Image](https://image.nuxt.com/providers/ipx)][1])

With **pnpm v10**, lifecycle/install scripts of dependencies are **blocked by default** unless explicitly allowed (e.g. via `pnpm.onlyBuiltDependencies` or `pnpm approve-builds`). This means `sharp`’s postinstall never runs, so its native binary is missing. ([[pnpm.io](https://pnpm.io/settings)][2], [[Socket](https://socket.dev/blog/pnpm-10-0-0-blocks-lifecycle-scripts-by-default)][3], [[GitHub](https://github.com/pnpm/pnpm/issues/9032)][4])

In my case, `pnpm approve-builds` (with no selections) also led to `sharp` being effectively ignored, keeping the failure in place.

### Reproduction

1. Create a new Nuxt app with **Nuxt UI Pro** and `@nuxt/image` enabled (default IPX).
2. Use **pnpm v10** (I’m on 10.13.1).
3. Add any local image and render it via `<UColorModeImage>` (which uses `<NuxtImg>` when `@nuxt/image` is installed). ([[Nuxt UI](https://ui.nuxt.com/components/color-mode-image)][5])
4. Start dev server and load the page.

### Actual behavior

* Requests to images handled by IPX return 500 with a `sharp` load error (see above).

### Expected behavior

* Images should load; IPX/sharp should be built/available out of the box.

### Environment

* **OS**: macOS (Apple Silicon) `arm64`
* **Node**: v22.15.1 (`arm64`)
* **pnpm**: v10.13.1
* **nuxt**: 4.0.3
* **@nuxt/image**: 1.11.0
* **@nuxt/ui-pro**: 3.3.0

### Diagnostics / What I tried

* Clearing `node_modules` + lockfile and reinstalling.
* `pnpm approve-builds` (initially with no packages selected → didn’t help).
* `pnpm rebuild sharp`.
* Upgrading `sharp` (e.g. to `^0.34.x`, which provides prebuilt `@img/*` binaries for darwin/arm64). ([[npm](https://www.npmjs.com/package/%40img/sharp-darwin-arm64)][6])

Root cause appears to be pnpm v10’s new defaults: install scripts are blocked unless whitelisted, so `sharp` never builds. ([[pnpm.io](https://pnpm.io/settings)][2])