### PR TITLE
chore: update compatibilityDate to 2026-06-30

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,7 +26,7 @@ export default defineNuxtConfig({
     }
   },
 
-  compatibilityDate: '2025-01-15',
+  compatibilityDate: '2026-06-30',
 
   nitro: {
     prerender: {


### PR DESCRIPTION
Updates the Nuxt `compatibilityDate` to today's date (2026-06-30).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s Nuxt compatibility date to a newer version, helping keep the project aligned with the latest framework support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->